### PR TITLE
Fix county-plot column typo

### DIFF
--- a/usa-ca/county-plot.py
+++ b/usa-ca/county-plot.py
@@ -151,7 +151,7 @@ try:
        'reported_tests'])
 except:
     # trying upper case and returning if date or DATE, area or AREA, cases or CASES, deaths or DEATHS, and modified c dataframe
-    DATE, AREA, CASES, DEATHS, c = reformat_counties_data_frame_with_columns(c, ['DATE', 'AREA', 'AREA_TYPE', 'POPULATUIB', 'CASES', 'DEATHS',
+    DATE, AREA, CASES, DEATHS, c = reformat_counties_data_frame_with_columns(c, ['DATE', 'AREA', 'AREA_TYPE', 'POPULATION', 'CASES', 'DEATHS',
        'TOTAL_TESTS', 'POSITIVE_TESTS', 'REPORTED_CASES', 'REPORTED_DEATHS',
        'REPORTED_TESTS'])
 


### PR DESCRIPTION
## Summary
- fix population column typo in `county-plot.py`

## Testing
- `python3 -m py_compile *.py usa-states/*.py usa-ca/*.py canada/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684941585bfc832e9f44a6845c46233a