### PR TITLE
Improve graph style

### DIFF
--- a/PLOTLY_THEME
+++ b/PLOTLY_THEME
@@ -1,4 +1,4 @@
-seaborn,Balto,14
+plotly_dark,Open Sans,16
 
 # Only first line is parsed. The rest is ignored and therefore are an explanation
 

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ covid19plot# ls --hide "run*" --hide "*html" -R -l
 -rw-r--r-- 1 root root 27338240 Mar  2 18:07 covid19-normal-perpop.html  # relative to population normal plots of country covid stats
 -rw-r--r-- 1 root root  7189726 Mar  2 18:07 places.html          # ranking countries from highest to lowest cases each day
 
--rw-r--r-- 1 root root   646 Mar  2 00:35 PLOTLY_THEME          # theme file
+-rw-r--r-- 1 root root   646 Mar  2 00:35 PLOTLY_THEME          # graph template,font,size settings
 -rw-r--r-- 1 root root  6155 Mar  1 22:10 README.md             # this readme
 -rw-r--r-- 1 root root     9 Mar  2 10:26 VERSION               # version
 -rwxr-xr-x 1 root root  1364 Feb 25 16:30 places.sh             # parses output files generated from run.sh & generates places.html 

--- a/common.py
+++ b/common.py
@@ -21,7 +21,7 @@ PER = 100000 # when we display relative data this is the per value so we do per 
 PER_TEXT = "100K" # text version, so we type less when we talk about it
 ndays = 7 # how many days is the moving average averaging
 predictdays = 30 # how many days to predict back and forward with linear regression fit
-COLOR_LIST = px.colors.qualitative.Vivid # this sets the colorway option in layout
+COLOR_LIST = px.colors.qualitative.Plotly # this sets the colorway option in layout
 COLOR_LIST_LEN = len(COLOR_LIST) # we will use the mod of this later
 
 #################


### PR DESCRIPTION
## Summary
- change default plotly theme to dark with larger fonts
- describe theme file more clearly in README
- use Plotly's default colour palette

## Testing
- `python3 -m py_compile $(find . -path ./example-output -prune -o -name '*.py' -print)`

------
https://chatgpt.com/codex/tasks/task_e_68494175584c832e907b3e232fd6d831